### PR TITLE
Fix paths from /boot/common to /boot/system

### DIFF
--- a/src/CommonFunctions.cpp
+++ b/src/CommonFunctions.cpp
@@ -88,7 +88,7 @@ void ExecutePreview(BString tmpData)
 	}
 	previewFile.Write(tmpData, strlen(tmpData));
 	previewFile.Unset();
-	pythonString = "/boot/common/bin/rst2html.py ";
+	pythonString = "/boot/system/bin/rst2html ";
 	pythonString += tmpInPath;
 	pythonString += " ";
 	pythonString += tmpOutPath;
@@ -136,11 +136,11 @@ void ExecutePublish(BString tmpData, int tmpFlag, BString tmpExt, entry_ref tmpR
 	previewFile.Write(tmpData, strlen(tmpData));
 	previewFile.Unset();
 
-	if(tmpExt == "odt") runPath = "/boot/common/bin/rst2odt.py ";
-	else if(tmpExt == "tex") runPath = "/boot/common/bin/rst2latex.py ";
-	else if(tmpExt == "htm") runPath = "/boot/common/bin/rst2html.py ";
-	else if(tmpExt == "xml") runPath = "/boot/common/bin/rst2xml.py ";
-	else if(tmpExt == "pdf") runPath = "/boot/common/bin/rst2pdf ";
+	if(tmpExt == "odt") runPath = "/boot/system/bin/rst2odt ";
+	else if(tmpExt == "tex") runPath = "/boot/system/bin/rst2latex ";
+	else if(tmpExt == "htm") runPath = "/boot/system/bin/rst2html ";
+	else if(tmpExt == "xml") runPath = "/boot/system/bin/rst2xml ";
+	else if(tmpExt == "pdf") runPath = "/boot/system/bin/rst2pdf ";
 	else
 	{
 		eAlert = new ErrorAlert("4.3 Publish File Type Error: Invalid filetype.");

--- a/src/PublishFilePanel.cpp
+++ b/src/PublishFilePanel.cpp
@@ -18,11 +18,11 @@ PublishFilePanel::PublishFilePanel(BMessenger* target)
 		{
 			BView* poseView = v->FindView("DirMenuField");
 			BView* parentview;
-			BEntry rst2pdfcheck("/boot/common/bin/rst2pdf");
-			BEntry rst2htmcheck("/boot/common/bin/rst2html.py");
-			BEntry rst2xmlcheck("/boot/common/bin/rst2xml.py");
-			BEntry rst2odtcheck("/boot/common/bin/rst2odt.py");
-			BEntry rst2texcheck("/boot/common/bin/rst2latex.py");
+			BEntry rst2pdfcheck("/boot/system/bin/rst2pdf");
+			BEntry rst2htmcheck("/boot/system/bin/rst2html");
+			BEntry rst2xmlcheck("/boot/system/bin/rst2xml");
+			BEntry rst2odtcheck("/boot/system/bin/rst2odt");
+			BEntry rst2texcheck("/boot/system/bin/rst2latex");
 			charWidth = cancelBtn->StringWidth("Select Current Directory");
 			btnrect = cancelBtn->Frame();
 			btnrect.right = btnrect.left - 10;


### PR DESCRIPTION
Without it it doesn't seem to find the python scripts:
```
> /Opslag/HaikuArchives/Masterpiece/src/objects.x86_64-cc13-release/Masterpiece
/bin/sh: line 1: /boot/common/bin/rst2html.py: No such file or directory
open: "/Opslag/HaikuArchives/Masterpiece/src/objects.x86_64-cc13-release/tmp.html": No such file or directory
```